### PR TITLE
Fix UI references and preset controls

### DIFF
--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -114,7 +114,7 @@
         <div class="row-inline">
           <button class="btn" id="pickFiles">Select files</button>
           <div id="filesCount" class="badge">0 files</div>
-          <button class="btn" id="openOutBtn" disabled>Open Output Folder</button>
+          <button class="btn" id="openOutBtn">Open Output Folder</button>
         </div>
         <div id="dropZone" class="small" tabindex="0" role="button" aria-label="Drop audio or video files and folders here" style="margin-top:8px;border:2px dashed #888;border-radius:10px;padding:24px;text-align:center;transition:background 120ms, border-color 120ms;">Drop files or folders here</div>
         <input id="fileInput" type="file" multiple webkitdirectory style="display:none" />
@@ -190,7 +190,7 @@
                 <div><label for="samplerate" title="Audio sample rate in Hz (e.g. 44100, 48000)">Sample rate (Hz)</label><input type="number" id="samplerate" placeholder="44100" /></div>
                 <div><label for="channels" title="Number of audio channels (1=mono, 2=stereo)">Channels</label><input type="number" id="channels" placeholder="2" /></div>
                 <div><label for="trim" title="Trim audio: start[-end] in seconds. E.g. 5-65 trims to 1:05.">Trim (start[-end] sec)</label><input type="text" id="trim" placeholder="5-65" /></div>
-                <div><label for="simpleConcurrency" title="How many files to convert at once. Higher = faster, but uses more CPU.">Concurrency</label><input type="number" id="simpleConcurrency" value="4" min="1" /></div>
+                <div><label for="concurrency" title="How many files to convert at once. Higher = faster, but uses more CPU.">Concurrency</label><input type="number" id="concurrency" value="4" min="1" /></div>
               </div>
             </details>
             <details>
@@ -355,7 +355,7 @@
     <script>
       const $ = (s)=>document.querySelector(s);
       const files = [];
-      const list = $('#files');
+      const list = $('#queueList');
       const progressList = $('#progressList');
       const logs = [];
 
@@ -482,8 +482,8 @@
       // Output Folder Open
       document.getElementById('openOutBtn').addEventListener('click', async () => {
         const outDir = $('#outDir').value;
-        if (window.vid2mp3?.openOutputFolder && outDir) {
-          await window.vid2mp3.openOutputFolder(outDir);
+        if (window.vid2mp3?.os?.openPath && outDir) {
+          await window.vid2mp3.os.openPath(outDir);
         } else {
           toast('Output folder open not supported.');
         }
@@ -843,7 +843,7 @@
         }
       }
 
-      document.getElementById('savePreset').addEventListener('click', async () => {
+      document.getElementById('presetSave').addEventListener('click', async () => {
         const name = document.getElementById('presetName').value.trim();
         if (!name) return toast('Please enter a preset name');
         // Gather current settings into an options object:
@@ -857,7 +857,7 @@
         }
       });
 
-      document.getElementById('loadPreset').addEventListener('click', async () => {
+      document.getElementById('presetLoad').addEventListener('click', async () => {
         const select = document.getElementById('presetSelect');
         const name = select.value;
         if (!name) return toast('Please select a preset');
@@ -906,13 +906,13 @@
         }
       });
 
-      document.getElementById('deletePreset').addEventListener('click', async () => {
+      document.getElementById('presetDel').addEventListener('click', async () => {
         const select = document.getElementById('presetSelect');
         const name = select.value;
         if (!name) return;
         if (!confirm(`Delete preset "${name}"?`)) return;
         try {
-          await window.vid2mp3.presets.delete(name);
+          await window.vid2mp3.presets.del(name);
           toast(`Preset "${name}" deleted`);
           updatePresetList();
         } catch {
@@ -928,7 +928,7 @@
           const allPresets = await window.vid2mp3.presets.list();
           if (defaultName && allPresets && defaultName in allPresets) {
             document.getElementById('presetSelect').value = defaultName;
-            document.getElementById('loadPreset').click();
+            document.getElementById('presetLoad').click();
           }
         }
       });

--- a/src/gui/main.ts
+++ b/src/gui/main.ts
@@ -189,6 +189,9 @@ function writeQueue(q: { pending: string[]; done: string[]; fail: string[] }) {
   fs.writeFileSync(p, JSON.stringify(q, null, 2), 'utf8');
 }
 
+ipcMain.handle('queue:pause', () => { __paused = true; });
+ipcMain.handle('queue:resume', () => { __paused = false; });
+
 function isBase64(str: string) {
   return /^[A-Za-z0-9+/=]+$/.test(str) && str.length % 4 === 0;
 }
@@ -341,13 +344,6 @@ ipcMain.handle('settings:save', async (_e, payload) => {
   writeSettings(payload || {});
   return true;
 });
-ipcMain.handle('presets:delete', async (_e, { name }) => {
-  const all = readPresets();
-  delete all[name];
-  writePresets(all);
-  return true;
-});
-
 // Resume controls
 ipcMain.handle('resume:get', async () => ({ enabled: __resumeEnabled, queue: readQueue() }));
 ipcMain.handle('resume:set', async (_e, { enabled }) => { __resumeEnabled = !!enabled; return true; });

--- a/src/gui/preload.ts
+++ b/src/gui/preload.ts
@@ -7,8 +7,12 @@ contextBridge.exposeInMainWorld('vid2mp3', {
   onProgress: (cb: (evt: any) => void) => ipcRenderer.on('progress', (_e, data) => cb(data)),
   presets: {
     list: () => ipcRenderer.invoke('presets:list'),
-    save: (name: string, options: any) => ipcRenderer.invoke('presets:save', { name, options }),
-    delete: (name: string) => ipcRenderer.invoke('presets:delete', { name }),
+    save: (name: string, data: any) => ipcRenderer.invoke('presets:save', { name, data }),
+    del: (name: string) => ipcRenderer.invoke('presets:del', name),
+    export: (name: string) => ipcRenderer.invoke('presets:export', name),
+    import: () => ipcRenderer.invoke('presets:import'),
+    setDefault: (name: string) => ipcRenderer.invoke('presets:setDefault', name),
+    getDefault: () => ipcRenderer.invoke('presets:getDefault'),
   },
   exportLogs: (content: string) => ipcRenderer.invoke('export-logs', { content }),
   queue: {


### PR DESCRIPTION
## Summary
- Use correct queue list element for file selection to allow UI initialization
- Restore advanced mode concurrency control with proper id
- Hook up preset save/load/delete buttons and expose full preset API
- Enable Open Output Folder button and implement queue pause/resume handlers

## Testing
- `npm run build`
- `node test-conversion.cjs` *(fails: test video file is empty)*
- `node test-probe.cjs` *(fails: ffprobe exited with code 1)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a521b5a9f8832bab9faabfcbbf3d50